### PR TITLE
Support tuples

### DIFF
--- a/test/datoms_differ/impl/core_helpers_test.cljc
+++ b/test/datoms_differ/impl/core_helpers_test.cljc
@@ -7,26 +7,74 @@
    :route/number {:db/unique :db.unique/identity}
    :route/services {:db/valueType :db.type/ref :db/cardinality :db.cardinality/many}
    :route/tags {:db/cardinality :db.cardinality/many}
+   :route/holidays {:db/valueType :db.type/ref :db/cardinality :db.cardinality/many}
    :service/trips {:db/valueType :db.type/ref :db/cardinality :db.cardinality/many :db/isComponent true}
    :trip/id {:db/unique :db.unique/identity}
    :service/id {:db/unique :db.unique/identity}
    :service/label {}
    :service/allocated-vessel {:db/valueType :db.type/ref :db/cardinality :db.cardinality/one}
    :vessel/imo {:db/unique :db.unique/identity}
-   :vessel/name {}})
+   :vessel/name {}
+   :holiday/bus-key {:db/unique :db.unique/identity
+                     :db/tupleAttrs [:holiday/pattern :holiday/weekday]}
+   :holiday/pattern {}
+   :holiday/weekday {}})
 
 (deftest finds-attrs
   (is (= (sut/find-attrs schema)
-         {:identity? #{:route/number :service/id :vessel/imo :trip/id}
-          :ref? #{:route/services :service/allocated-vessel :service/trips}
-          :many? #{:route/services :service/trips :route/tags}
-          :component? #{:service/trips}})))
+         {:identity? #{:route/number :service/id :vessel/imo :trip/id :holiday/bus-key}
+          :ref? #{:route/services :service/allocated-vessel :service/trips :route/holidays}
+          :many? #{:route/services :service/trips :route/tags :route/holidays}
+          :component? #{:service/trips}
+          :tuple? {:holiday/bus-key [:holiday/pattern :holiday/weekday]}}))
+
+  (testing "tuple attribute referencing many attribute throws"
+    (try
+      (sut/find-attrs {:a-many {:db/valueType :db.type/ref :db/cardinality :db.cardinality/many}
+                       :b {}
+                       :tup {:db/tupleAttrs [:a-many :b]}})
+      (is (= :should-throw :didnt))
+      (catch Exception e
+        (is (= "Tuple attribute can't reference cardinality many attribute" (.getMessage e)))
+        (is (= {:attr :tup
+                :conflict #{:a-many}}
+               (ex-data e))))))
+
+  (testing "tuple attribute referencing another tuple attribute throws"
+    (try
+      (sut/find-attrs {:a {}
+                       :b {}
+                       :tup {:db/tupleAttrs [:a :b]}
+                       :c {}
+                       :tup2 {:db/tupleAttrs [:c :tup]}})
+      (is (= :should-throw :didnt))
+      (catch Exception e
+        (is (= "Tuple attribute can't reference another tuple attribute" (.getMessage e)))
+        (is (= {:attr :tup2
+                :conflict #{:tup}}
+               (ex-data e)))))))
 
 (def attrs (sut/find-attrs schema))
+
+(deftest add-tuple-attributes
+  (is (= (sut/add-tuple-attributes attrs {:holiday/pattern :christmas-day :holiday/weekday :sunday})
+         {:holiday/bus-key [:christmas-day :sunday]
+          :holiday/pattern :christmas-day
+          :holiday/weekday :sunday}))
+  (is (= (sut/add-tuple-attributes attrs {:holiday/weekday :sunday})
+         {:holiday/bus-key [nil :sunday]
+          :holiday/weekday :sunday}))
+  (is (= (sut/add-tuple-attributes attrs {:foo :bar})
+         {:foo :bar})))
 
 (deftest gets-entity-refs
   (is (= (sut/get-entity-ref attrs {:route/number "100" :route/name "Stavanger-Tau"})
          [:route/number "100"]))
+
+  (is (= (->> {:holiday/pattern :christmas-eve :holiday/weekday :sunday}
+              (sut/add-tuple-attributes attrs)
+              (sut/get-entity-ref attrs))
+         [:holiday/bus-key [:christmas-eve :sunday]]))
 
   (is (thrown? Exception ;; multiple identity attributes
                (sut/get-entity-ref attrs {:route/number "100" :service/id 200 :route/name "Stavanger-Tau"})))


### PR DESCRIPTION
Since DataScript 1.0.0 tuple attributes are now supported. Described [here](https://github.com/tonsky/datascript/blob/master/docs/tuples.md).

This PR allows adding tupleAttrs to your schema and have datoms-differ automatically keep track of appropriate add/retracts and datoms for export/synching. 